### PR TITLE
Workaround close wait

### DIFF
--- a/conf.d/servers/graph.conf
+++ b/conf.d/servers/graph.conf
@@ -18,6 +18,16 @@ server {
                 include /etc/nginx/conf.d/parts/http.conf;
         }
         
+        # Workaround for CLOSE_WAIT bug
+        location /_ml {
+                # proxy_pass http://graph-backends-dc1;
+                # secure graph-backends
+                proxy_pass https://graph-backends-secure-dc1;
+                
+                include /etc/nginx/conf.d/parts/http.conf;
+                proxy_ignore_client_abort on;
+        }
+        
         location /apps {
                 # proxy_pass http://frontends-dc1;
                 # secure frontends

--- a/conf.d/servers/graph2.conf
+++ b/conf.d/servers/graph2.conf
@@ -20,9 +20,9 @@ server {
         
         # Workaround for CLOSE_WAIT bug
         location /_ml {
-                # proxy_pass http://graph-backends-dc1;
+                # proxy_pass http://graph-backends-dc2;
                 # secure graph-backends
-                proxy_pass https://graph-backends-secure-dc1;
+                proxy_pass https://graph-backends-secure-dc2;
                 
                 include /etc/nginx/conf.d/parts/http.conf;
                 proxy_ignore_client_abort on;

--- a/conf.d/servers/graph2.conf
+++ b/conf.d/servers/graph2.conf
@@ -18,6 +18,16 @@ server {
                 include /etc/nginx/conf.d/parts/http.conf;
         }
         
+        # Workaround for CLOSE_WAIT bug
+        location /_ml {
+                # proxy_pass http://graph-backends-dc1;
+                # secure graph-backends
+                proxy_pass https://graph-backends-secure-dc1;
+                
+                include /etc/nginx/conf.d/parts/http.conf;
+                proxy_ignore_client_abort on;
+        }
+        
         location /apps {
                 # proxy_pass http://frontends-dc2;
                 # secure frontends


### PR DESCRIPTION
Hi, this configures nginx to keep the connection to the /_ml service even when the engine closes the connection prematurely. This should avoid the CLOSE_WAIT situation.