### PR TITLE
workaround for halfy read responses

### DIFF
--- a/conf.d/parts/http.conf
+++ b/conf.d/parts/http.conf
@@ -6,6 +6,8 @@ proxy_set_header   X-Forwarded-For  $remote_addr;
 proxy_set_header   Host $http_host;
 proxy_http_version 1.1;
 
+proxy_set_header Connection "";
+
 proxy_read_timeout 15m;
 proxy_send_timeout 15m;
 client_max_body_size 1024m;


### PR DESCRIPTION
this disables connection: close in the direction of the backend servers.