### PR TITLE
Patch to support WSO2IS 5.9.0

### DIFF
--- a/conf.d/servers/iam.conf
+++ b/conf.d/servers/iam.conf
@@ -25,6 +25,9 @@ server {
 
         location ~ /api/ {
         proxy_pass  https://iam-backends-dc1-RR;
+        # make Mutial SSL authentication work
+        # see: https://is.docs.wso2.com/en/5.9.0/develop/authenticating-and-authorizing-rest-apis/
+        proxy_set_header X-SSL-CERT $ssl_client_escaped_cert;
         include /etc/nginx/conf.d/parts/http.conf;
         }
 }


### PR DESCRIPTION
not having this patch causes internal api calls
(relying on Mutial SSL authentication) to fail

will fix problem with session limit check:
https://www.pivotaltracker.com/story/show/170360124