### PR TITLE
Do not enable SSL validation by default

### DIFF
--- a/conf.d/servers/iam.conf
+++ b/conf.d/servers/iam.conf
@@ -9,9 +9,10 @@ server {
 
         ssl_certificate     /etc/pki/tls/certs/iam.crt;
         ssl_certificate_key /etc/pki/tls/private/hiro.key;
-        # make Mutual SSL authentication work (required for session limit check)
-        ssl_client_certificate /etc/pki/tls/certs/iam.crt;
-	ssl_verify_client optional;
+        # make Mutual SSL authentication work
+        # (enable only for session limit check)
+        #ssl_client_certificate /etc/pki/tls/certs/iam.crt;
+	#ssl_verify_client optional;
         
         include /etc/nginx/conf.d/parts/server.conf;
 


### PR DESCRIPTION
might cause some faulty behavior if clients
have some (unrelated) certificates installed